### PR TITLE
Remove first quarter goal & add pageID variable.

### DIFF
--- a/project/scroll-tracking.js
+++ b/project/scroll-tracking.js
@@ -1,5 +1,12 @@
 /*******************************************************************************
 
+  AUTHOR:
+
+    Kyle Rush, Head of Optimization at Optimizely
+    - http://kylerush.net
+    - https://github.com/kylerush
+    - https://twitter.com/kylerush
+
   OVERVIEW:
 
     An Optimizely Project JavaScript snippet that tracks to which quarter of
@@ -9,10 +16,20 @@
     If the user is on the /pricing page, the custom event goal in Optimizely
     will have these values:
 
-    - "/pricing first quarter viewed"
     - "/pricing second quarter viewed"
     - "/pricing third quarter viewed"
     - "/pricing fourth quarter viwed"
+
+  OPTIONS:
+
+    pageID (string)
+      You can define a global variable on the window object to identify the page
+      rather than relying on window.location.pathname. This is helpful when
+      doing redirect experiments that show two different versions of a page.
+      When you define window.pageID = '/pricing' in the variation code for each
+      variation, even though the actual URLs are different, this script will
+      still report /pricing for the conversion goal so that you can compare the
+      two pages against each other.
 
   NOTES:
 
@@ -31,21 +48,22 @@
 
   var report = function(quarter){
 
+    var pageID = w.optimizelyScrollTrackerID ? w.optimizelyScrollTrackerID : w.location.pathname.replace(/\/$/, '');
+
     w.optimizely = w.optimizely || [];
 
     //report with raw optimizely
-    w.optimizely.push(['trackEvent', w.location.pathname.replace(/\/$/, '') + ' ' + quarter + ' quarter viewed']);
+    w.optimizely.push(['trackEvent', pageID + ' ' + quarter + ' quarter viewed']);
 
     //report to ga (optional)
-    //w.ga('send', 'event', 'scroll', w.location.pathname.replace(/\/$/, ''), quarter + ' quarter viewed');
+    //w.ga('send', 'event', 'scroll', pageID, quarter + ' quarter viewed');
 
   };
 
   $(function(){
 
-    var firstQuarterViewed, secondQuarterViewed, thirdQuarterViewed, fourthQuarterViewed, quarters;
+    var secondQuarterViewed, thirdQuarterViewed, fourthQuarterViewed, quarters;
 
-    firstQuarterViewed = false;
     secondQuarterViewed = false;
     thirdQuarterViewed = false;
     fourthQuarterViewed = false;
@@ -54,22 +72,17 @@
 
     $(w).scroll(function(){
 
-      if(w.pageYOffset <= quarters * 1){
-        if(!firstQuarterViewed){
-          report('first');
-          firstQuarterViewed = true;
-        }
-      } else if(w.pageYOffset <= quarters * 2){
+      if(w.pageYOffset <= quarters * 2 && w.pageYOffset > quarters){
         if(!secondQuarterViewed){
           report('second');
           secondQuarterViewed = true;
         }
-      } else if(w.pageYOffset <= quarters * 3){
+      } else if(w.pageYOffset <= quarters * 3 && w.pageYOffset > quarters * 2){
         if(!thirdQuarterViewed){
           report('third');
           thirdQuarterViewed = true;
         }
-      } else if (!fourthQuarterViewed){
+      } else if (!fourthQuarterViewed && w.pageYOffset > quarters * 3){
         report('fourth');
         fourthQuarterViewed = true;
       }


### PR DESCRIPTION
It didn't make sense to report a scroll on the first quarter of the page since so I removed that. I also added a `pageID` option to override the `window.location.pathname` in the custom event which is helpful if you have two pages with different URLs.
